### PR TITLE
Rectified the NoReverseMatch error at auth/registration/

### DIFF
--- a/fedgehundapi/urls.py
+++ b/fedgehundapi/urls.py
@@ -15,7 +15,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path, re_path
-from rest_auth.registration.views import VerifyEmailView, RegisterView
+from rest_auth.registration.views import VerifyEmailView
 
 urlpatterns = [
     path('admin/', admin.site.urls),


### PR DESCRIPTION

It was a problem occurring when Django was trying to verify the user's email.  

[https://stackoverflow.com/questions/57944943/django-rest-auth-registration-error-after-creating-new-user-account-confirm-ema](url)

@FedgeHund/summerintern2020
